### PR TITLE
fix: remove números de nome de funções

### DIFF
--- a/src/crud/indices/ArvoreBMais_String_Int.java
+++ b/src/crud/indices/ArvoreBMais_String_Int.java
@@ -186,7 +186,7 @@ public class ArvoreBMais_String_Int {
     
         
     // Busca recursiva por um elemento a partir da chave. Este metodo invoca 
-    // o método recursivo read1, passando a raiz como referência.
+    // o método recursivo readOne, passando a raiz como referência.
     public int read(String c) throws IOException {
         
         // Recupera a raiz da árvore
@@ -196,14 +196,14 @@ public class ArvoreBMais_String_Int {
         
         // Executa a busca recursiva
         if(raiz!=-1)
-            return read1(c,raiz);
+            return readOne(c,raiz);
         else
             return -1;
     }
     
     // Busca recursiva. Este método recebe a referência de uma página e busca
     // pela chave na mesma. A busca continua pelos filhos, se houverem.
-    private int read1(String chave, long pagina) throws IOException {
+    private int readOne(String chave, long pagina) throws IOException {
         
         // Como a busca é recursiva, a descida para um filho inexistente
         // (filho de uma página folha) retorna um valor negativo.
@@ -237,9 +237,9 @@ public class ArvoreBMais_String_Int {
         
         // Terceiro passo - ainda não é uma folha, continua a busca recursiva pela árvore
         if(i==pa.n || chave.compareTo(pa.chaves[i])<0)
-            return read1(chave, pa.filhos[i]);
+            return readOne(chave, pa.filhos[i]);
         else
-            return read1(chave, pa.filhos[i+1]);
+            return readOne(chave, pa.filhos[i+1]);
     }
         
     // Atualiza recursivamente um valor a partir da sua chave. Este metodo invoca 
@@ -332,7 +332,7 @@ public class ArvoreBMais_String_Int {
                 
         // Chamada recursiva para a inserção da chave e do valor
         // A chave e o valor não são passados como parâmetros, porque são globais
-        boolean inserido = create1(pagina);
+        boolean inserido = createOne(pagina);
         
         // Testa a necessidade de criação de uma nova raiz.
         if(cresceu) {
@@ -361,7 +361,7 @@ public class ArvoreBMais_String_Int {
     
     // Função recursiva de inclusão. A função passa uma página de referência.
     // As inclusões são sempre feitas em uma folha.
-    private boolean create1(long pagina) throws IOException {
+    private boolean createOne(long pagina) throws IOException {
         
         // Testa se passou para o filho de uma página folha. Nesse caso, 
         // inicializa as variáveis globais de controle.
@@ -397,9 +397,9 @@ public class ArvoreBMais_String_Int {
         // filho inexistente de uma página folha ser alcançado.
         boolean inserido;
         if(i==pa.n || chaveAux.compareTo(pa.chaves[i])<0)
-            inserido = create1(pa.filhos[i]);
+            inserido = createOne(pa.filhos[i]);
         else
-            inserido = create1(pa.filhos[i+1]);
+            inserido = createOne(pa.filhos[i+1]);
         
         // A partir deste ponto, as chamadas recursivas já foram encerradas. 
         // Assim, o próximo código só é executado ao retornar das chamadas recursivas.
@@ -567,7 +567,7 @@ public class ArvoreBMais_String_Int {
                 
         // Chama recursivamente a exclusão de registro (na chave1Aux e no 
         // chave2Aux) passando uma página como referência
-        boolean excluido = delete1(chave, pagina);
+        boolean excluido = deleteOne(chave, pagina);
         
         // Se a exclusão tiver sido possível e a página tiver reduzido seu tamanho,
         // por meio da fusão das duas páginas filhas da raiz, elimina essa raiz
@@ -594,7 +594,7 @@ public class ArvoreBMais_String_Int {
 
     // Função recursiva de exclusão. A função passa uma página de referência.
     // As exclusões são sempre feitas em folhas e a fusão é propagada para cima.
-    private boolean delete1(String chave, long pagina) throws IOException {
+    private boolean deleteOne(String chave, long pagina) throws IOException {
         
         // Declaração de variáveis
         boolean excluido=false;
@@ -654,10 +654,10 @@ public class ArvoreBMais_String_Int {
         // pode ter ficado com menos elementos do que o mínimo necessário.
         // Essa página será filha da página atual
         if(i==pa.n || chave.compareTo(pa.chaves[i])<0) {
-            excluido = delete1(chave, pa.filhos[i]);
+            excluido = deleteOne(chave, pa.filhos[i]);
             diminuido = i;
         } else {
-            excluido = delete1(chave, pa.filhos[i+1]);
+            excluido = deleteOne(chave, pa.filhos[i+1]);
             diminuido = i+1;
         }
         
@@ -876,12 +876,12 @@ public class ArvoreBMais_String_Int {
         arquivo.seek(0);
         raiz = arquivo.readLong();
         if(raiz!=-1)
-            print1(raiz);
+            printOne(raiz);
         System.out.println();
     }
     
     // Impressão recursiva
-    private void print1(long pagina) throws IOException {
+    private void printOne(long pagina) throws IOException {
         
         // Retorna das chamadas recursivas
         if(pagina==-1)
@@ -910,8 +910,8 @@ public class ArvoreBMais_String_Int {
         // Chama recursivamente cada filho, se a página não for folha
         if(pa.filhos[0] != -1) {
             for(i=0; i<pa.n; i++)
-                print1(pa.filhos[i]);
-            print1(pa.filhos[i]);
+                printOne(pa.filhos[i]);
+            printOne(pa.filhos[i]);
         }
     }
        

--- a/src/crud/indices/HashExtensivel.java
+++ b/src/crud/indices/HashExtensivel.java
@@ -28,10 +28,10 @@ public class HashExtensivel {
    
     String           nomeArquivoDiretorio;
     String           nomeArquivoCestos;
-    RandomAccessFile arqDiretório;
+    RandomAccessFile arqDiretorio;
     RandomAccessFile arqCestos;
     int              quantidadeDadosPorCesto;
-    Diretório        diretório;
+    Diretorio        diretorio;
     
     class Cesto {
 
@@ -184,12 +184,12 @@ public class HashExtensivel {
 
     }
 
-    class Diretório {
+    class Diretorio {
 
         byte   profundidadeGlobal;
         long[] endereços;
 
-        public Diretório() {
+        public Diretorio() {
             profundidadeGlobal = 0;
             endereços = new long[1];
             endereços[0] = 0;
@@ -283,18 +283,18 @@ public class HashExtensivel {
         nomeArquivoCestos = nc;
         
         
-        arqDiretório = new RandomAccessFile(nomeArquivoDiretorio,"rw");
+        arqDiretorio = new RandomAccessFile(nomeArquivoDiretorio,"rw");
         arqCestos = new RandomAccessFile(nomeArquivoCestos,"rw");
 
-        // Se o diretório ou os cestos estiverem vazios, cria um novo diretório e lista de cestos
-        if(arqDiretório.length()==0 || arqCestos.length()==0) {
+        // Se o diretorio ou os cestos estiverem vazios, cria um novo diretorio e lista de cestos
+        if(arqDiretorio.length()==0 || arqCestos.length()==0) {
 
-            // Cria um novo diretório, com profundidade de 0 bits (1 único elemento)
-            diretório = new Diretório();
-            byte[] bd = diretório.toByteArray();
-            arqDiretório.write(bd);
+            // Cria um novo diretorio, com profundidade de 0 bits (1 único elemento)
+            diretorio = new Diretorio();
+            byte[] bd = diretorio.toByteArray();
+            arqDiretorio.write(bd);
             
-            // Cria um cesto vazio, já apontado pelo único elemento do diretório
+            // Cria um cesto vazio, já apontado pelo único elemento do diretorio
             Cesto c = new Cesto(quantidadeDadosPorCesto);
             bd = c.toByteArray();
             arqCestos.seek(0);
@@ -304,18 +304,18 @@ public class HashExtensivel {
     
     public boolean create(int chave, long dado) throws Exception {
         
-        //Carrega o diretório
-        byte[] bd = new byte[(int)arqDiretório.length()];
-        arqDiretório.seek(0);
-        arqDiretório.read(bd);
-        diretório = new Diretório();
-        diretório.fromByteArray(bd);        
+        //Carrega o diretorio
+        byte[] bd = new byte[(int)arqDiretorio.length()];
+        arqDiretorio.seek(0);
+        arqDiretorio.read(bd);
+        diretorio = new Diretorio();
+        diretorio.fromByteArray(bd);        
         
-        // Identifica a hash do diretório,
-        int i = diretório.hash(chave);
+        // Identifica a hash do diretorio,
+        int i = diretorio.hash(chave);
         
         // Recupera o cesto
-        long endereçoCesto = diretório.endereço(i);
+        long endereçoCesto = diretorio.endereço(i);
         Cesto c = new Cesto(quantidadeDadosPorCesto);
         byte[] ba = new byte[c.size()];
         arqCestos.seek(endereçoCesto);
@@ -336,11 +336,11 @@ public class HashExtensivel {
             return true;        
         }
         
-        // Duplica o diretório
+        // Duplica o diretorio
         byte pl = c.profundidadeLocal;
-        if(pl>=diretório.profundidadeGlobal)
-            diretório.duplica();
-        byte pg = diretório.profundidadeGlobal;
+        if(pl>=diretorio.profundidadeGlobal)
+            diretorio.duplica();
+        byte pg = diretorio.profundidadeGlobal;
 
         // Cria os novos cestos, com os seus dados no arquivo de cestos
         Cesto c1 = new Cesto(quantidadeDadosPorCesto, pl+1);
@@ -352,21 +352,21 @@ public class HashExtensivel {
         arqCestos.seek(novoEndereço);
         arqCestos.write(c2.toByteArray());
         
-        // Atualiza os dados no diretório
-        int inicio = diretório.hash2(chave, c.profundidadeLocal);
+        // Atualiza os dados no diretorio
+        int inicio = diretorio.hash2(chave, c.profundidadeLocal);
         int deslocamento = (int)Math.pow(2,pl);
         int max = (int)Math.pow(2,pg);
         boolean troca = false;
         for(int j=inicio; j<max; j+=deslocamento) {
             if(troca)
-                diretório.atualizaEndereco(j,novoEndereço);
+                diretorio.atualizaEndereco(j,novoEndereço);
             troca=!troca;
         }
         
-        // Atualiza o arquivo do diretório
-        bd = diretório.toByteArray();
-        arqDiretório.seek(0);
-        arqDiretório.write(bd);
+        // Atualiza o arquivo do diretorio
+        bd = diretorio.toByteArray();
+        arqDiretorio.seek(0);
+        arqDiretorio.write(bd);
         
         // Reinsere as chaves
         for(int j=0; j<c.quantidade; j++) {
@@ -379,18 +379,18 @@ public class HashExtensivel {
     
     public long read(int chave) throws Exception {
         
-        //Carrega o diretório
-        byte[] bd = new byte[(int)arqDiretório.length()];
-        arqDiretório.seek(0);
-        arqDiretório.read(bd);
-        diretório = new Diretório();
-        diretório.fromByteArray(bd);        
+        //Carrega o diretorio
+        byte[] bd = new byte[(int)arqDiretorio.length()];
+        arqDiretorio.seek(0);
+        arqDiretorio.read(bd);
+        diretorio = new Diretorio();
+        diretorio.fromByteArray(bd);        
         
-        // Identifica a hash do diretório,
-        int i = diretório.hash(chave);
+        // Identifica a hash do diretorio,
+        int i = diretorio.hash(chave);
         
         // Recupera o cesto
-        long endereçoCesto = diretório.endereço(i);
+        long endereçoCesto = diretorio.endereço(i);
         Cesto c = new Cesto(quantidadeDadosPorCesto);
         byte[] ba = new byte[c.size()];
         arqCestos.seek(endereçoCesto);
@@ -402,18 +402,18 @@ public class HashExtensivel {
     
     public boolean update(int chave, long novoDado) throws Exception {
         
-        //Carrega o diretório
-        byte[] bd = new byte[(int)arqDiretório.length()];
-        arqDiretório.seek(0);
-        arqDiretório.read(bd);
-        diretório = new Diretório();
-        diretório.fromByteArray(bd);        
+        //Carrega o diretorio
+        byte[] bd = new byte[(int)arqDiretorio.length()];
+        arqDiretorio.seek(0);
+        arqDiretorio.read(bd);
+        diretorio = new Diretorio();
+        diretorio.fromByteArray(bd);        
         
-        // Identifica a hash do diretório,
-        int i = diretório.hash(chave);
+        // Identifica a hash do diretorio,
+        int i = diretorio.hash(chave);
         
         // Recupera o cesto
-        long endereçoCesto = diretório.endereço(i);
+        long endereçoCesto = diretorio.endereço(i);
         Cesto c = new Cesto(quantidadeDadosPorCesto);
         byte[] ba = new byte[c.size()];
         arqCestos.seek(endereçoCesto);
@@ -433,18 +433,18 @@ public class HashExtensivel {
     
     public boolean delete(int chave) throws Exception {
         
-        //Carrega o diretório
-        byte[] bd = new byte[(int)arqDiretório.length()];
-        arqDiretório.seek(0);
-        arqDiretório.read(bd);
-        diretório = new Diretório();
-        diretório.fromByteArray(bd);        
+        //Carrega o diretorio
+        byte[] bd = new byte[(int)arqDiretorio.length()];
+        arqDiretorio.seek(0);
+        arqDiretorio.read(bd);
+        diretorio = new Diretorio();
+        diretorio.fromByteArray(bd);        
         
-        // Identifica a hash do diretório,
-        int i = diretório.hash(chave);
+        // Identifica a hash do diretorio,
+        int i = diretorio.hash(chave);
         
         // Recupera o cesto
-        long endereçoCesto = diretório.endereço(i);
+        long endereçoCesto = diretorio.endereço(i);
         Cesto c = new Cesto(quantidadeDadosPorCesto);
         byte[] ba = new byte[c.size()];
         arqCestos.seek(endereçoCesto);
@@ -463,13 +463,13 @@ public class HashExtensivel {
     
     public void print() {
         try {
-            byte[] bd = new byte[(int)arqDiretório.length()];
-            arqDiretório.seek(0);
-            arqDiretório.read(bd);
-            diretório = new Diretório();
-            diretório.fromByteArray(bd);   
-            System.out.println("\nDIRETÓRIO ------------------");
-            System.out.println(diretório);
+            byte[] bd = new byte[(int)arqDiretorio.length()];
+            arqDiretorio.seek(0);
+            arqDiretorio.read(bd);
+            diretorio = new Diretorio();
+            diretorio.fromByteArray(bd);   
+            System.out.println("\nDIREToRIO ------------------");
+            System.out.println(diretorio);
 
             System.out.println("\nCESTOS ---------------------");
             arqCestos.seek(0);

--- a/src/menu/Selecao.java
+++ b/src/menu/Selecao.java
@@ -71,6 +71,7 @@ class Selecao {
             System.out.println(graficos.caixa(5,"PERGUNTAS 1.0"));
 
             //Imprimindo o menu a ser exibido para o usuario
+            // TODO: trocar switch por object literal?
             switch(menuIndex) 
             {
 


### PR DESCRIPTION
Nomes de funções devem optar sempre por texto. Quanto às variáveis, creio que caracteres que exijam UTF-8 podem trazer possíveis complicações dependendo da máquina onde o projeto for executado